### PR TITLE
Make same changes as in fuzzyjoin to adapt to tidyr v1.0.0

### DIFF
--- a/R/intersect.R
+++ b/R/intersect.R
@@ -65,8 +65,8 @@ genome_intersect <- function(x, y, by=NULL, mode= "both"){
     # nest around the chromosome column
     x$..index <- seq_len(nrow(x))
     y$..index <- seq_len(nrow(y))
-    nested_x <- tidyr::nest_(x, "x_data", colnames(x)[-1])
-    nested_y <- tidyr::nest_(y, "y_data", colnames(y)[-1])
+    nested_x <- dplyr::group_by_at(x, 1) %>% tidyr::nest()
+    nested_y <- dplyr::group_by_at(y, 1) %>% tidyr::nest()
     by <- c(colnames(nested_y)[1])
     names(by) <- colnames(nested_x)[1]
 
@@ -82,7 +82,7 @@ genome_intersect <- function(x, y, by=NULL, mode= "both"){
                  ..start=IRanges::start(intersection), ..end=IRanges::end(intersection))
     }
 
-    ret <- purrr::map2_df(joined$x_data, joined$y_data, find_overlaps)
+    ret <- purrr::map2_df(joined$data.x, joined$data.y, find_overlaps)
     ret
   }
 

--- a/R/join_closest.R
+++ b/R/join_closest.R
@@ -52,8 +52,9 @@ genome_join_closest <- function(x, y, by=NULL,  mode = "inner",
     # nest around the chromosome column
     x$..index <- seq_len(nrow(x))
     y$..index <- seq_len(nrow(y))
-    nested_x <- tidyr::nest_(x, "x_data", colnames(x)[-1])
-    nested_y <- tidyr::nest_(y, "y_data", colnames(y)[-1])
+
+    nested_x <- dplyr::group_by_at(x, 1) %>% tidyr::nest()
+    nested_y <- dplyr::group_by_at(y, 1) %>% tidyr::nest()
     by <- c(colnames(nested_y)[1])
     names(by) <- colnames(nested_x)[1]
 
@@ -69,7 +70,7 @@ genome_join_closest <- function(x, y, by=NULL,  mode = "inner",
         dplyr::filter(`..distance` < max_distance)
     }
 
-    ret <- purrr::map2_df(joined$x_data, joined$y_data, find_closest)
+    ret <- purrr::map2_df(joined$data.x, joined$data.y, find_closest)
 
     if(! is.null(distance_column_name)){
       ret[[distance_column_name]] <- ret$..distance

--- a/R/subtract.R
+++ b/R/subtract.R
@@ -54,8 +54,8 @@ genome_subtract <- function(x, y, by=NULL){
     # nest around the chromosome column
     x$..index <- seq_len(nrow(x))
     y$..index <- seq_len(nrow(y))
-    nested_x <- tidyr::nest_(x, "x_data", colnames(x)[-1])
-    nested_y <- tidyr::nest_(y, "y_data", colnames(y)[-1])
+    nested_x <- dplyr::group_by_at(x, 1) %>% tidyr::nest()
+    nested_y <- dplyr::group_by_at(y, 1) %>% tidyr::nest()
     by <- c(colnames(nested_y)[1])
     names(by) <- colnames(nested_x)[1]
 
@@ -74,7 +74,7 @@ genome_subtract <- function(x, y, by=NULL){
                  ..end=pmin(IRanges::end(subtraction)[o$queryHits], IRanges::end(r1)[o$subjectHits]))
     }
 
-    ret <- purrr::map2_df(joined$x_data, joined$y_data, find_subtractions)
+    ret <- purrr::map2_df(joined$data.x, joined$data.y, find_subtractions)
     ret
   }
 


### PR DESCRIPTION
We are working towards a release of tidyr v1.0.0. `tidyr::nest_()` has been deprecated for a while and will become defunct in this release. This PR makes the same changes made in fuzzyjoin (https://github.com/dgrtwo/fuzzyjoin/commit/a39fc462c6030766b0ba77c916ba66d190b97df6) to modify these calls. This code works with CRAN and dev tidyr.

tidygenomics will fail `R CMD check` until fuzzyjoin releases on CRAN, since there are calls to `fuzzyjoin::genome_join()` in the intro vignette. So it would make sense to submit to CRAN after fuzzyjoin but before tidyr.