### PR TITLE
Avoid underscored functions

### DIFF
--- a/R/cluster.R
+++ b/R/cluster.R
@@ -38,7 +38,7 @@ genome_cluster <- function(x, by=NULL, max_distance=0, cluster_column_name="clus
     g <- purrr::map_chr(x_groups, as.character)
     missing <- !(g %in% colnames(d))
     g[missing] <- paste0(g[missing], ".x")
-    dplyr::group_by_(d, .dots = g)
+    dplyr::group_by(d, dplyr::pick(dplyr::all_of(g)))
   }
 
   if (is.null(by) | length(by) != 3) {

--- a/R/intersect.R
+++ b/R/intersect.R
@@ -49,7 +49,7 @@ genome_intersect <- function(x, y, by=NULL, mode= "both"){
     g <- purrr::map_chr(x_groups, as.character)
     missing <- !(g %in% colnames(d))
     g[missing] <- paste0(g[missing], ".x")
-    dplyr::group_by_(d, .dots = g)
+    dplyr::group_by(d, dplyr::pick(dplyr::all_of(g)))
   }
 
   mode <- match.arg(mode, c("both", "left", "right", "anti"))

--- a/R/subtract.R
+++ b/R/subtract.R
@@ -40,7 +40,7 @@ genome_subtract <- function(x, y, by=NULL){
     g <- purrr::map_chr(x_groups, as.character)
     missing <- !(g %in% colnames(d))
     g[missing] <- paste0(g[missing], ".x")
-    dplyr::group_by_(d, .dots = g)
+    dplyr::group_by(d, dplyr::pick(dplyr::all_of(g)))
   }
 
   by <- dplyr::common_by(by, x, y)


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package uses one of the "underscored" versions of a dplyr verb, such as `mutate_()` rather than `mutate()`. These were deprecated in 2017, and are now defunct and must be removed.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!